### PR TITLE
do pixel list each iteration, add flag for showing input images

### DIFF
--- a/demoInputFile.m
+++ b/demoInputFile.m
@@ -34,6 +34,7 @@ inputs.zRefs = 7;                    % assumed z level of ref points
 % 4.  Processing parameters
 inputs.doImageProducts = 1;                    % usually 1.
 inputs.showFoundRefPoints = 0;                 % to display ref points as check
+inputs.showInputImages = 1;                    % display each input image as it is processed
 inputs.rectxy = [50 0.5 500 400 0.5 1000];     % rectification specs
 inputs.rectz = 0;                              % rectification z-level
 

--- a/findCOMRefObj.m
+++ b/findCOMRefObj.m
@@ -35,9 +35,10 @@ Vr(i) = mean(V(good));
 % plot option
 if meta.showFoundRefPoints
     figure(1+10);clf; colormap(gray)
-    imagesc(URef,VRef,I2)
+    imagesc(URef,VRef,I2); axis image
     hold on
     plot(Ur(i),Vr(i),'r*')
+    drawnow
 end
 du = round(Ur(i) - uv(1));     % rough corrections to search guesses
 dv = round(Vr(i) - uv(2));
@@ -54,9 +55,10 @@ for i = 2: size(xyz,1)
     % plot option
     if meta.showFoundRefPoints
         figure(i+10);clf; colormap(gray)
-        imagesc(URef,VRef,I2)
+        imagesc(URef,VRef,I2); axis image
         hold on
         plot(Ur(i),Vr(i),'r*')
+        drawnow
     end
 end
 

--- a/findCOMRefObj.m
+++ b/findCOMRefObj.m
@@ -45,9 +45,12 @@ dv = round(Vr(i) - uv(2));
 
 for i = 2: size(xyz,1)
     uv = round(findUVnDOF(beta,xyz(i,:), meta.globals));
-    uv = uv(:) + [du; dv];
-    URef = [uv(1)-dUV(i,1): uv(1)+dUV(i,1)];
-    VRef = [uv(2)-dUV(i,2): uv(2)+dUV(i,2)];
+    uv = uv(:) + [du; dv];    
+    URef = [uv(1)-dUV(i,1): uv(1)+dUV(i,1)];    %This is a problem if the search region heads out of view!!  (Negative indices!)
+    VRef = [uv(2)-dUV(i,2): uv(2)+dUV(i,2)];  
+    % you may not go off the edge! 
+     URef = URef( find(URef>0)); URef = URef( find(URef<size(I,2)+1)); 
+     VRef = VRef( find(VRef>0)); VRef = VRef( find(VRef<size(I,1)+1));
     I2 = I(VRef,URef);
     [U,V] = meshgrid(URef,VRef);
     Ur(i) = mean(U(I2>thresh(i)));

--- a/findCOMRefObjFirstPass.m
+++ b/findCOMRefObjFirstPass.m
@@ -18,7 +18,7 @@ cont = 1;
 while ~isempty(cont)
     figure(10); clf
     colormap(jet)
-    subplot(121); imagesc(u,v,i); colorbar
+    subplot(121); imagesc(u,v,i); axis image; colorbar
     thresh = input('enter a threshold to isolate the target - ');
 
     Ur = mean(U(i>thresh));
@@ -26,7 +26,8 @@ while ~isempty(cont)
     hold on; plot(Ur,Vr, 'w*')
     figure(10);subplot(122)
     imagesc(u,v,i>thresh)
-    hold on; plot(Ur,Vr,'w*')
+    hold on; plot(Ur,Vr,'w*'); 
+    axis image; 
     cont = input('Enter <cr> to accept, 0 to try again - ');
 end
 close(10)

--- a/findNewBeta.m
+++ b/findNewBeta.m
@@ -30,7 +30,7 @@ beta6dof(find(~meta.globals.knownFlags)) = betaNew;
 if( meta.showInputImages == 1 )
     % show results in case debug is needed
     figure(2); clf; colormap(gray)
-    imagesc(Ig)
+    imagesc(Ig); axis image
     hold on
     plot(Ur,Vr,'r*')
     uv = findUVnDOF(beta6dof, xyz, globs);

--- a/findNewBeta.m
+++ b/findNewBeta.m
@@ -27,14 +27,17 @@ betaNew = nlinfit(xyz,[Ur(:); Vr(:)],'findUVnDOF',beta);
 beta6dof(find(meta.globals.knownFlags)) = meta.globals.knowns;
 beta6dof(find(~meta.globals.knownFlags)) = betaNew;
 
-% show results in case debug is needed
-figure(2); clf; colormap(gray)
-imagesc(Ig)
-hold on
-plot(Ur,Vr,'r*')
-uv = findUVnDOF(beta6dof, xyz, globs);
-uv = reshape(uv,[],2);
-plot(uv(:,1),uv(:,2),'ko')
+if( meta.showInputImages == 1 )
+    % show results in case debug is needed
+    figure(2); clf; colormap(gray)
+    imagesc(Ig)
+    hold on
+    plot(Ur,Vr,'r*')
+    uv = findUVnDOF(beta6dof, xyz, globs);
+    uv = reshape(uv,[],2);
+    plot(uv(:,1),uv(:,2),'ko')
+    hold off; drawnow;
+end;
 
 %
 %   Copyright (C) 2017  Coastal Imaging Research Network

--- a/initUAVAnalysis.m
+++ b/initUAVAnalysis.m
@@ -22,11 +22,20 @@ xyz = [x' y' z'];
 
 % digitize the gcps and find best fit geometry
 figure(1); clf
-imagesc(I);
+imagesc(I); axis image; 
 disp(['computing geometry using ' num2str(nGcps) ' control points'])
-for i = 1: nGcps
-    disp(['Digitize ' gcp(in.gcpList(i)).name])
+zoom reset
+for i = 1: nGcps    
+    disp(['Zoom in to see ' gcp(in.gcpList(i)).name ' then press Enter'])
+    tit = title(['Zoom in to see ' gcp(in.gcpList(i)).name ' then press Enter']);     
+    zoom on; 
+    pause
+    zoom off; 
+    disp(['Digitize ' gcp(in.gcpList(i)).name])    
+    tit = title(['Now digitize ' gcp(in.gcpList(i)).name ]); 
     UV(i,:) = ginput(1);     
+    delete(tit)
+    zoom out
 end
 beta = nlinfit(xyz,[UV(:,1); UV(:,2)],'findUVnDOF',in.beta0);
 
@@ -35,7 +44,7 @@ hold on
 plot(UV(:,1),UV(:,2),'g*')
 UV2 = findUVnDOF(beta,xyz,globs);
 UV2 = reshape(UV2,[],2);
-plot(UV2(:,1),UV2(:,2),'ro')
+plot(UV2(:,1),UV2(:,2),'ro'); 
 
 % now identify nRefPoints reference points
 disp(' ')
@@ -45,7 +54,7 @@ disp('to allow for inter-frame aim point wander.')
 disp(' ')
 foo = input('Hit <Enter> to replot image and continue - ');
 figure(1);clf
-imagesc(I)
+imagesc(I); axis image; 
 Ig = rgb2gray(I);
 disp('PICK FIRST POINT WITH LARGE BOUNDING BOX')
 clear refPoints
@@ -56,12 +65,15 @@ beta6DOF(find(~globs.knownFlags)) = beta;
 for i = 1: in.nRefs
     disp(['pick top left and bottom right corner of point ' ...
         num2str(i) ' of ' num2str(in.nRefs)])
+    tit = title(['pick top left and bottom right corner of point ' ...
+        num2str(i) ' of ' num2str(in.nRefs)]); 
     c = ginput(2);
     [refPoints(i).Ur,refPoints(i).Vr, refPoints(i).thresh] = ...
         findCOMRefObjFirstPass(Ig, c);
     refPoints(i).dUV = round(diff(c)/2);
     refPoints(i).xyz = findXYZ6dof(refPoints(i).Ur, refPoints(i).Vr, in.zRefs, ...
         beta6DOF, meta.globals.lcp);
+    delete(tit);
 end
 
 

--- a/makePixelInstsDemo.m
+++ b/makePixelInstsDemo.m
@@ -2,14 +2,17 @@ function r = makePixelInstsDemo( )
 
 % Make pixel instruments using pixel toolbox. duplicate of demoInstsFile.
 
+% start by forgetting everything you know
 PIXForget;
+% and set the station name
 PIXSetStation('aerielle');
 
+% sea level
 zmsl = 0;
 
 instID = [];
 
-% vbar insts
+% vbar insts, two y transects 
 y = [450 700];
 x = [125:25:225];
 
@@ -35,7 +38,7 @@ for ii=1:length(y)
     instID = [instID tid];
 end
 
-% cBathy
+% cBathy, 5 meter points
 dx = 5;
 dy = 5;
 x1 = 80;

--- a/makePixelInstsDemo.m
+++ b/makePixelInstsDemo.m
@@ -27,7 +27,7 @@ end
 % runup
 xshore = 125;
 xdune  = 70;
-y = 60:50:650;
+y = 600:50:650;
 rot = 0;
 
 for ii=1:length(y)

--- a/makePixelInstsDemo.m
+++ b/makePixelInstsDemo.m
@@ -25,6 +25,12 @@ for ii=1:length(x)
 end
 
 % runup
+% note: normally for a runup line you want to keep a fixed X and Y.
+% This requires knowing the Z for each point on the line. For a fixed
+% station you may have done the survey transects or have other information
+% that allows you to know that. For a UAV operation, you probably do not,
+% Thus this is the "no Z" call.
+
 xshore = 125;
 xdune  = 70;
 y = 600:50:650;

--- a/makePixelInstsDemo.m
+++ b/makePixelInstsDemo.m
@@ -61,7 +61,7 @@ pid = PIXCreatePackage('AerielleDemo', instID);
 e = matlab2Epoch(now);
 
 % build the initial r
-r = PIXCreateR( pid, e, zmsl, 'none' );
+r = PIXCreateR( pid, e, zmsl, 'uav' );
 
 end
 

--- a/sampleAerielleVideoDemo.m
+++ b/sampleAerielleVideoDemo.m
@@ -56,6 +56,7 @@ I = imread([inputs.pnIn filesep clipFns(1).name filesep fns{1}(1).name]);
 [NV, NU, NC] = size(I);
 Ig = rgb2gray(I);           % for later sampling.
 meta.showFoundRefPoints = inputs.showFoundRefPoints; % easy way to pass.
+meta.showInputImages = inputs.showInputImages;
 
 % Because nlinfit requires globals, we set up a variable globals (under 
 % metadata) that contains the lcp as well as the flags and values for

--- a/sampleAerielleVideoDemoPIX.m
+++ b/sampleAerielleVideoDemoPIX.m
@@ -1,4 +1,4 @@
-ei% sample an example Aerielle movie.  Set this up as generic for other
+% sample an example Aerielle movie.  Set this up as generic for other
 % movies 
 
 % The important things are:
@@ -6,6 +6,10 @@ ei% sample an example Aerielle movie.  Set this up as generic for other
 %       records for each UAV analysis.
 %   - a gcp file from a current survey
 %   - 
+%
+%  also important, you need the PIXel-Toolbox repo from github, which is 
+%  right next to the UAV toolbox you already have. 
+%
 
 clear
 close all

--- a/sampleAerielleVideoDemoPIX.m
+++ b/sampleAerielleVideoDemoPIX.m
@@ -100,6 +100,7 @@ r = PIXParameterizeR( r, cam, geom, ip );
 r = PIXRebuildCollect( r );
 
 showInsts(I, r);
+xlabel('u (pix)'); ylabel('v (pix)'); title('Demo Run Time Exposure')
 
 % if you don't see what you hoped to see, stop and re-create instruments.
 foo = input('Hit Ctrl-C if instruments not proper in Figure 3, otherwise <Enter> ');
@@ -110,8 +111,6 @@ nPix = size(r.cams(1).U, 1);
 stack.data = nan(nt, nPix, 1 );
 
 %%
-
-xlabel('x (m)'); ylabel('y (m)'); title('Demo Run Time Exposure')
 
 % now save metadata if it wasn't already there
 if  oldGeoms==0

--- a/sampleAerielleVideoDemoPIX.m
+++ b/sampleAerielleVideoDemoPIX.m
@@ -1,4 +1,4 @@
-% sample an example Aerielle movie.  Set this up as generic for other
+ei% sample an example Aerielle movie.  Set this up as generic for other
 % movies 
 
 % The important things are:
@@ -9,6 +9,9 @@
 
 clear
 close all
+
+addpath neededCILRoutines
+addpath ../PIXEL-Toolbox
 
 % required USER INPUT material.  Adapt to each collection
 demoInputFile;      % this file contains all of the required inputs.
@@ -43,6 +46,7 @@ I = imread([inputs.pnIn filesep clipFns(1).name filesep fns{1}(1).name]);
 [NV, NU, NC] = size(I);
 Ig = rgb2gray(I);           % for later sampling.
 meta.showFoundRefPoints = inputs.showFoundRefPoints; % easy way to pass.
+meta.showInputImages = inputs.showInputImages;       % ditto
 
 % Because nlinfit requires globals, we set up a variable globals (under 
 % metadata) that contains the lcp as well as the flags and values for
@@ -89,7 +93,6 @@ end
 % set up instruments and stacks - always do this.
 [geom, cam, ip] = lcpBeta2GeomCamIp( meta.globals.lcp, betas(1,:) );
 r = PIXParameterizeR( r, cam, geom, ip );
-
 r = PIXRebuildCollect( r );
 
 showInsts(I, r);
@@ -185,6 +188,12 @@ for clip = 1: NClips    % this is only relevant if you have multiple clips
         if isnan(betas(cnt,1))
             break;
         end
+
+        % must redo r for each new beta
+        [geom, cam, ip] = lcpBeta2GeomCamIp( meta.globals.lcp, betas(cnt,:) );
+        r = PIXParameterizeR( r, cam, geom, ip );
+        r = PIXRebuildCollect( r );
+
         data = sampleDJIFrame(r, Ig, betas(cnt,:), meta.globals);
             stack.data(cnt,:) = data';
         if inputs.doImageProducts


### PR DESCRIPTION
js-pixfix updates development to fix an issue with the pixel toolbox use in sampleAerielleVideoDemoPIX, and to add a flag to both sampleAerielleVideoDemo(PIX) functions to control display of input images in figure 2 by findNewBeta (and changes that file to see the flag). 

The PIX version needed a fix so that the 'r' pixel list is updated for each input frame after the new beta values are calculated (moving images). 

The flag for findNewBeta is to let the user STOP the incessant plotting of the input images, and to fix a bug where it was not drawing new images anyway. Every time figure 2 was updated it draws the window focus, so you cannot do anything else but watch this. This is controlled by a new flag in the inputs struct loaded in demoInputFile.m called input.showInputImages. it defaults to the current 'master' behavior of "show the inputs", or "1". 

The PIX version requires the latest master from the PIXEL-Toolbox, which I have already updated. It must understand the 'uav' sortBy flag.
