### PR TITLE
Add files via upload

### DIFF
--- a/findCOMRefObj.m
+++ b/findCOMRefObj.m
@@ -45,9 +45,12 @@ dv = round(Vr(i) - uv(2));
 
 for i = 2: size(xyz,1)
     uv = round(findUVnDOF(beta,xyz(i,:), meta.globals));
-    uv = uv(:) + [du; dv];
-    URef = [uv(1)-dUV(i,1): uv(1)+dUV(i,1)];
-    VRef = [uv(2)-dUV(i,2): uv(2)+dUV(i,2)];
+    uv = uv(:) + [du; dv];    
+    URef = [uv(1)-dUV(i,1): uv(1)+dUV(i,1)];    %This is a problem if the search region heads out of view!!  (Negative indices!)
+    VRef = [uv(2)-dUV(i,2): uv(2)+dUV(i,2)];  
+    % you may not go off the edge! 
+     URef = URef( find(URef>0)); URef = URef( find(URef<size(I,2)+1)); 
+     VRef = VRef( find(VRef>0)); VRef = VRef( find(VRef<size(I,1)+1));
     I2 = I(VRef,URef);
     [U,V] = meshgrid(URef,VRef);
     Ur(i) = mean(U(I2>thresh(i)));


### PR DESCRIPTION
Sorry, I noticed that the movement correction broke if the search window moved off the boundary of the image.... 
I had to make a change to `findCOMRefObj.m` to avoid problems when refPoints search region drifts off the edge of the image for  i=2:size(xyz,1) refPoints. It's the same fix that you already had for the i=1 window.

Otherwise, everything is same as current js-pixfix and passes my final testing. After this merges to js-pixfix, please merge js-pixfix to development. 
